### PR TITLE
fix: actually run UDAF constructors

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,3 @@
 use nix -A python39
 watch_file poetry.lock
+eval "$shellHook"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           extraPullNames: nix-community,stupidb
 
       - name: Build package and run tests
-        run: nix build -L --argstr python python${{ matrix.python-version }}
+        run: cachix watch-exec slumba nix -- build -L --argstr python python${{ matrix.python-version }} --keep-going
   conda:
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ name: Continuous Integration
 jobs:
   nix:
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
         run: nix build -L --argstr python python${{ matrix.python-version }}
   conda:
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - "3.7"

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,4 @@
 [mypy]
-exclude = slumba/tests/test_.*\.py
-
 ignore_missing_imports = true
 
 # untyped things

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-exclude = slumba/tests/.*\.py
+exclude = slumba/tests/test_.*\.py
 
 ignore_missing_imports = true
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5d73f669a84b5271ae0993244b389411794a1a47",
-        "sha256": "0bbmdfgg1x6k5wzvx4371mv0f29xlhl4vng0rpap3jlwf7qlcwf9",
+        "rev": "5edf5b60c3d8f82b5fc5e73e822b6f7460584945",
+        "sha256": "0gbb07mhbn9m8askxsy87h9737sr45qhnrjhkkix3jl136my2ppz",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5d73f669a84b5271ae0993244b389411794a1a47.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5edf5b60c3d8f82b5fc5e73e822b6f7460584945.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {

--- a/poetry-overrides.nix
+++ b/poetry-overrides.nix
@@ -9,8 +9,4 @@
       self.flit
     ];
   });
-
-  mypy = super.mypy.overridePythonAttrs (_: {
-    MYPY_USE_MYPYC = false;
-  });
 }

--- a/poetry-overrides.nix
+++ b/poetry-overrides.nix
@@ -4,9 +4,16 @@
       export LLVM_CONFIG=${llvm.dev}/bin/llvm-config
     '';
   });
+
   tomli = super.tomli.overridePythonAttrs (old: {
     propagatedNativeBuildInputs = (old.propagatedNativeBuildInputs or [ ]) ++ [
       self.flit
+    ];
+  });
+
+  pytest-randomly = super.pytest-randomly.overridePythonAttrs (old: {
+    propagatedBuildInputs = (old.propagatedBuildInputs or [ ]) ++ [
+      self.importlib-metadata
     ];
   });
 }

--- a/poetry.lock
+++ b/poetry.lock
@@ -351,6 +351,18 @@ py = "*"
 pytest = ">=3.10"
 
 [[package]]
+name = "pytest-randomly"
+version = "3.10.1"
+description = "Pytest plugin to randomly order tests and control random.seed."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+importlib-metadata = {version = ">=3.6.0", markers = "python_version < \"3.10\""}
+pytest = "*"
+
+[[package]]
 name = "pytest-xdist"
 version = "2.3.0"
 description = "pytest xdist plugin for distributed testing and loop-on-failing modes"
@@ -430,7 +442,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.8,<3.10"
-content-hash = "d621675fab8a43ca5ce8e7a16d54614263771c3df5804291828ae1759f66cfbd"
+content-hash = "876117cdaf1d2da92668f026677898ee3e37058136737033be30f9ae7d5496fa"
 
 [metadata.files]
 appdirs = [
@@ -732,6 +744,10 @@ pytest-benchmark = [
 pytest-forked = [
     {file = "pytest-forked-1.3.0.tar.gz", hash = "sha256:6aa9ac7e00ad1a539c41bec6d21011332de671e938c7637378ec9710204e37ca"},
     {file = "pytest_forked-1.3.0-py2.py3-none-any.whl", hash = "sha256:dc4147784048e70ef5d437951728825a131b81714b398d5d52f17c7c144d8815"},
+]
+pytest-randomly = [
+    {file = "pytest-randomly-3.10.1.tar.gz", hash = "sha256:d4ef5dbf27e542e6a4e4cec7a20ef3f1b906bce21fa340ca5657b5326ef23a64"},
+    {file = "pytest_randomly-3.10.1-py3-none-any.whl", hash = "sha256:d28d490e3a743bdd64c5bc87c5fc182eac966ba6432c6bb6b224e32e76527e9e"},
 ]
 pytest-xdist = [
     {file = "pytest-xdist-2.3.0.tar.gz", hash = "sha256:e8ecde2f85d88fbcadb7d28cb33da0fa29bca5cf7d5967fa89fc0e97e5299ea5"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -170,7 +170,7 @@ python-versions = "*"
 
 [[package]]
 name = "mypy"
-version = "0.910"
+version = "0.812"
 description = "Optional static typing for Python"
 category = "dev"
 optional = false
@@ -178,13 +178,11 @@ python-versions = ">=3.5"
 
 [package.dependencies]
 mypy-extensions = ">=0.4.3,<0.5.0"
-toml = "*"
-typed-ast = {version = ">=1.4.0,<1.5.0", markers = "python_version < \"3.8\""}
+typed-ast = ">=1.4.0,<1.5.0"
 typing-extensions = ">=3.7.4"
 
 [package.extras]
 dmypy = ["psutil (>=4.0)"]
-python2 = ["typed-ast (>=1.4.0,<1.5.0)"]
 
 [[package]]
 name = "mypy-extensions"
@@ -371,7 +369,7 @@ testing = ["filelock"]
 
 [[package]]
 name = "regex"
-version = "2021.8.3"
+version = "2021.8.21"
 description = "Alternative regular expression module, to replace re."
 category = "dev"
 optional = false
@@ -432,7 +430,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.8,<3.10"
-content-hash = "ed77ac8c81accdcb53fbcc4aa07829b4ad10eb6add7d501202a08382bf53bd3d"
+content-hash = "d621675fab8a43ca5ce8e7a16d54614263771c3df5804291828ae1759f66cfbd"
 
 [metadata.files]
 appdirs = [
@@ -606,29 +604,28 @@ mccabe = [
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 mypy = [
-    {file = "mypy-0.910-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:a155d80ea6cee511a3694b108c4494a39f42de11ee4e61e72bc424c490e46457"},
-    {file = "mypy-0.910-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:b94e4b785e304a04ea0828759172a15add27088520dc7e49ceade7834275bedb"},
-    {file = "mypy-0.910-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:088cd9c7904b4ad80bec811053272986611b84221835e079be5bcad029e79dd9"},
-    {file = "mypy-0.910-cp35-cp35m-win_amd64.whl", hash = "sha256:adaeee09bfde366d2c13fe6093a7df5df83c9a2ba98638c7d76b010694db760e"},
-    {file = "mypy-0.910-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:ecd2c3fe726758037234c93df7e98deb257fd15c24c9180dacf1ef829da5f921"},
-    {file = "mypy-0.910-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:d9dd839eb0dc1bbe866a288ba3c1afc33a202015d2ad83b31e875b5905a079b6"},
-    {file = "mypy-0.910-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:3e382b29f8e0ccf19a2df2b29a167591245df90c0b5a2542249873b5c1d78212"},
-    {file = "mypy-0.910-cp36-cp36m-win_amd64.whl", hash = "sha256:53fd2eb27a8ee2892614370896956af2ff61254c275aaee4c230ae771cadd885"},
-    {file = "mypy-0.910-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b6fb13123aeef4a3abbcfd7e71773ff3ff1526a7d3dc538f3929a49b42be03f0"},
-    {file = "mypy-0.910-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e4dab234478e3bd3ce83bac4193b2ecd9cf94e720ddd95ce69840273bf44f6de"},
-    {file = "mypy-0.910-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:7df1ead20c81371ccd6091fa3e2878559b5c4d4caadaf1a484cf88d93ca06703"},
-    {file = "mypy-0.910-cp37-cp37m-win_amd64.whl", hash = "sha256:0aadfb2d3935988ec3815952e44058a3100499f5be5b28c34ac9d79f002a4a9a"},
-    {file = "mypy-0.910-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ec4e0cd079db280b6bdabdc807047ff3e199f334050db5cbb91ba3e959a67504"},
-    {file = "mypy-0.910-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:119bed3832d961f3a880787bf621634ba042cb8dc850a7429f643508eeac97b9"},
-    {file = "mypy-0.910-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:866c41f28cee548475f146aa4d39a51cf3b6a84246969f3759cb3e9c742fc072"},
-    {file = "mypy-0.910-cp38-cp38-win_amd64.whl", hash = "sha256:ceb6e0a6e27fb364fb3853389607cf7eb3a126ad335790fa1e14ed02fba50811"},
-    {file = "mypy-0.910-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1a85e280d4d217150ce8cb1a6dddffd14e753a4e0c3cf90baabb32cefa41b59e"},
-    {file = "mypy-0.910-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:42c266ced41b65ed40a282c575705325fa7991af370036d3f134518336636f5b"},
-    {file = "mypy-0.910-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:3c4b8ca36877fc75339253721f69603a9c7fdb5d4d5a95a1a1b899d8b86a4de2"},
-    {file = "mypy-0.910-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:c0df2d30ed496a08de5daed2a9ea807d07c21ae0ab23acf541ab88c24b26ab97"},
-    {file = "mypy-0.910-cp39-cp39-win_amd64.whl", hash = "sha256:c6c2602dffb74867498f86e6129fd52a2770c48b7cd3ece77ada4fa38f94eba8"},
-    {file = "mypy-0.910-py3-none-any.whl", hash = "sha256:ef565033fa5a958e62796867b1df10c40263ea9ded87164d67572834e57a174d"},
-    {file = "mypy-0.910.tar.gz", hash = "sha256:704098302473cb31a218f1775a873b376b30b4c18229421e9e9dc8916fd16150"},
+    {file = "mypy-0.812-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:a26f8ec704e5a7423c8824d425086705e381b4f1dfdef6e3a1edab7ba174ec49"},
+    {file = "mypy-0.812-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:28fb5479c494b1bab244620685e2eb3c3f988d71fd5d64cc753195e8ed53df7c"},
+    {file = "mypy-0.812-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:9743c91088d396c1a5a3c9978354b61b0382b4e3c440ce83cf77994a43e8c521"},
+    {file = "mypy-0.812-cp35-cp35m-win_amd64.whl", hash = "sha256:d7da2e1d5f558c37d6e8c1246f1aec1e7349e4913d8fb3cb289a35de573fe2eb"},
+    {file = "mypy-0.812-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:4eec37370483331d13514c3f55f446fc5248d6373e7029a29ecb7b7494851e7a"},
+    {file = "mypy-0.812-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:d65cc1df038ef55a99e617431f0553cd77763869eebdf9042403e16089fe746c"},
+    {file = "mypy-0.812-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:61a3d5b97955422964be6b3baf05ff2ce7f26f52c85dd88db11d5e03e146a3a6"},
+    {file = "mypy-0.812-cp36-cp36m-win_amd64.whl", hash = "sha256:25adde9b862f8f9aac9d2d11971f226bd4c8fbaa89fb76bdadb267ef22d10064"},
+    {file = "mypy-0.812-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:552a815579aa1e995f39fd05dde6cd378e191b063f031f2acfe73ce9fb7f9e56"},
+    {file = "mypy-0.812-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:499c798053cdebcaa916eef8cd733e5584b5909f789de856b482cd7d069bdad8"},
+    {file = "mypy-0.812-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:5873888fff1c7cf5b71efbe80e0e73153fe9212fafdf8e44adfe4c20ec9f82d7"},
+    {file = "mypy-0.812-cp37-cp37m-win_amd64.whl", hash = "sha256:9f94aac67a2045ec719ffe6111df543bac7874cee01f41928f6969756e030564"},
+    {file = "mypy-0.812-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d23e0ea196702d918b60c8288561e722bf437d82cb7ef2edcd98cfa38905d506"},
+    {file = "mypy-0.812-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:674e822aa665b9fd75130c6c5f5ed9564a38c6cea6a6432ce47eafb68ee578c5"},
+    {file = "mypy-0.812-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:abf7e0c3cf117c44d9285cc6128856106183938c68fd4944763003decdcfeb66"},
+    {file = "mypy-0.812-cp38-cp38-win_amd64.whl", hash = "sha256:0d0a87c0e7e3a9becdfbe936c981d32e5ee0ccda3e0f07e1ef2c3d1a817cf73e"},
+    {file = "mypy-0.812-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7ce3175801d0ae5fdfa79b4f0cfed08807af4d075b402b7e294e6aa72af9aa2a"},
+    {file = "mypy-0.812-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:b09669bcda124e83708f34a94606e01b614fa71931d356c1f1a5297ba11f110a"},
+    {file = "mypy-0.812-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:33f159443db0829d16f0a8d83d94df3109bb6dd801975fe86bacb9bf71628e97"},
+    {file = "mypy-0.812-cp39-cp39-win_amd64.whl", hash = "sha256:3f2aca7f68580dc2508289c729bd49ee929a436208d2b2b6aab15745a70a57df"},
+    {file = "mypy-0.812-py3-none-any.whl", hash = "sha256:2f9b3407c58347a452fc0736861593e105139b905cca7d097e413453a1d650b4"},
+    {file = "mypy-0.812.tar.gz", hash = "sha256:cd07039aa5df222037005b08fbbfd69b3ab0b0bd7a07d7906de75ae52c4e3119"},
 ]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
@@ -741,39 +738,47 @@ pytest-xdist = [
     {file = "pytest_xdist-2.3.0-py3-none-any.whl", hash = "sha256:ed3d7da961070fce2a01818b51f6888327fb88df4379edeb6b9d990e789d9c8d"},
 ]
 regex = [
-    {file = "regex-2021.8.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:8764a78c5464ac6bde91a8c87dd718c27c1cabb7ed2b4beaf36d3e8e390567f9"},
-    {file = "regex-2021.8.3-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4551728b767f35f86b8e5ec19a363df87450c7376d7419c3cac5b9ceb4bce576"},
-    {file = "regex-2021.8.3-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:577737ec3d4c195c4aef01b757905779a9e9aee608fa1cf0aec16b5576c893d3"},
-    {file = "regex-2021.8.3-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c856ec9b42e5af4fe2d8e75970fcc3a2c15925cbcc6e7a9bcb44583b10b95e80"},
-    {file = "regex-2021.8.3-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3835de96524a7b6869a6c710b26c90e94558c31006e96ca3cf6af6751b27dca1"},
-    {file = "regex-2021.8.3-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:cea56288eeda8b7511d507bbe7790d89ae7049daa5f51ae31a35ae3c05408531"},
-    {file = "regex-2021.8.3-cp36-cp36m-win32.whl", hash = "sha256:a4eddbe2a715b2dd3849afbdeacf1cc283160b24e09baf64fa5675f51940419d"},
-    {file = "regex-2021.8.3-cp36-cp36m-win_amd64.whl", hash = "sha256:57fece29f7cc55d882fe282d9de52f2f522bb85290555b49394102f3621751ee"},
-    {file = "regex-2021.8.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a5c6dbe09aff091adfa8c7cfc1a0e83fdb8021ddb2c183512775a14f1435fe16"},
-    {file = "regex-2021.8.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ff4a8ad9638b7ca52313d8732f37ecd5fd3c8e3aff10a8ccb93176fd5b3812f6"},
-    {file = "regex-2021.8.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b63e3571b24a7959017573b6455e05b675050bbbea69408f35f3cb984ec54363"},
-    {file = "regex-2021.8.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:fbc20975eee093efa2071de80df7f972b7b35e560b213aafabcec7c0bd00bd8c"},
-    {file = "regex-2021.8.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:14caacd1853e40103f59571f169704367e79fb78fac3d6d09ac84d9197cadd16"},
-    {file = "regex-2021.8.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:bb350eb1060591d8e89d6bac4713d41006cd4d479f5e11db334a48ff8999512f"},
-    {file = "regex-2021.8.3-cp37-cp37m-win32.whl", hash = "sha256:18fdc51458abc0a974822333bd3a932d4e06ba2a3243e9a1da305668bd62ec6d"},
-    {file = "regex-2021.8.3-cp37-cp37m-win_amd64.whl", hash = "sha256:026beb631097a4a3def7299aa5825e05e057de3c6d72b139c37813bfa351274b"},
-    {file = "regex-2021.8.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:16d9eaa8c7e91537516c20da37db975f09ac2e7772a0694b245076c6d68f85da"},
-    {file = "regex-2021.8.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3905c86cc4ab6d71635d6419a6f8d972cab7c634539bba6053c47354fd04452c"},
-    {file = "regex-2021.8.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:937b20955806381e08e54bd9d71f83276d1f883264808521b70b33d98e4dec5d"},
-    {file = "regex-2021.8.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:28e8af338240b6f39713a34e337c3813047896ace09d51593d6907c66c0708ba"},
-    {file = "regex-2021.8.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c09d88a07483231119f5017904db8f60ad67906efac3f1baa31b9b7f7cca281"},
-    {file = "regex-2021.8.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:85f568892422a0e96235eb8ea6c5a41c8ccbf55576a2260c0160800dbd7c4f20"},
-    {file = "regex-2021.8.3-cp38-cp38-win32.whl", hash = "sha256:bf6d987edd4a44dd2fa2723fca2790f9442ae4de2c8438e53fcb1befdf5d823a"},
-    {file = "regex-2021.8.3-cp38-cp38-win_amd64.whl", hash = "sha256:8fe58d9f6e3d1abf690174fd75800fda9bdc23d2a287e77758dc0e8567e38ce6"},
-    {file = "regex-2021.8.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7976d410e42be9ae7458c1816a416218364e06e162b82e42f7060737e711d9ce"},
-    {file = "regex-2021.8.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9569da9e78f0947b249370cb8fadf1015a193c359e7e442ac9ecc585d937f08d"},
-    {file = "regex-2021.8.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:459bbe342c5b2dec5c5223e7c363f291558bc27982ef39ffd6569e8c082bdc83"},
-    {file = "regex-2021.8.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:4f421e3cdd3a273bace013751c345f4ebeef08f05e8c10757533ada360b51a39"},
-    {file = "regex-2021.8.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ea212df6e5d3f60341aef46401d32fcfded85593af1d82b8b4a7a68cd67fdd6b"},
-    {file = "regex-2021.8.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a3b73390511edd2db2d34ff09aa0b2c08be974c71b4c0505b4a048d5dc128c2b"},
-    {file = "regex-2021.8.3-cp39-cp39-win32.whl", hash = "sha256:f35567470ee6dbfb946f069ed5f5615b40edcbb5f1e6e1d3d2b114468d505fc6"},
-    {file = "regex-2021.8.3-cp39-cp39-win_amd64.whl", hash = "sha256:bfa6a679410b394600eafd16336b2ce8de43e9b13f7fb9247d84ef5ad2b45e91"},
-    {file = "regex-2021.8.3.tar.gz", hash = "sha256:8935937dad2c9b369c3d932b0edbc52a62647c2afb2fafc0c280f14a8bf56a6a"},
+    {file = "regex-2021.8.21-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4b0c211c55d4aac4309c3209833c803fada3fc21cdf7b74abedda42a0c9dc3ce"},
+    {file = "regex-2021.8.21-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d5209c3ba25864b1a57461526ebde31483db295fc6195fdfc4f8355e10f7376"},
+    {file = "regex-2021.8.21-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c835c30f3af5c63a80917b72115e1defb83de99c73bc727bddd979a3b449e183"},
+    {file = "regex-2021.8.21-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:615fb5a524cffc91ab4490b69e10ae76c1ccbfa3383ea2fad72e54a85c7d47dd"},
+    {file = "regex-2021.8.21-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9966337353e436e6ba652814b0a957a517feb492a98b8f9d3b6ba76d22301dcc"},
+    {file = "regex-2021.8.21-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a49f85f0a099a5755d0a2cc6fc337e3cb945ad6390ec892332c691ab0a045882"},
+    {file = "regex-2021.8.21-cp310-cp310-win32.whl", hash = "sha256:f93a9d8804f4cec9da6c26c8cfae2c777028b4fdd9f49de0302e26e00bb86504"},
+    {file = "regex-2021.8.21-cp310-cp310-win_amd64.whl", hash = "sha256:a795829dc522227265d72b25d6ee6f6d41eb2105c15912c230097c8f5bfdbcdc"},
+    {file = "regex-2021.8.21-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:bca14dfcfd9aae06d7d8d7e105539bd77d39d06caaae57a1ce945670bae744e0"},
+    {file = "regex-2021.8.21-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41acdd6d64cd56f857e271009966c2ffcbd07ec9149ca91f71088574eaa4278a"},
+    {file = "regex-2021.8.21-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:96f0c79a70642dfdf7e6a018ebcbea7ea5205e27d8e019cad442d2acfc9af267"},
+    {file = "regex-2021.8.21-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:45f97ade892ace20252e5ccecdd7515c7df5feeb42c3d2a8b8c55920c3551c30"},
+    {file = "regex-2021.8.21-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f9974826aeeda32a76648fc677e3125ade379869a84aa964b683984a2dea9f1"},
+    {file = "regex-2021.8.21-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ea9753d64cba6f226947c318a923dadaf1e21cd8db02f71652405263daa1f033"},
+    {file = "regex-2021.8.21-cp36-cp36m-win32.whl", hash = "sha256:ef9326c64349e2d718373415814e754183057ebc092261387a2c2f732d9172b2"},
+    {file = "regex-2021.8.21-cp36-cp36m-win_amd64.whl", hash = "sha256:6dbd51c3db300ce9d3171f4106da18fe49e7045232630fe3d4c6e37cb2b39ab9"},
+    {file = "regex-2021.8.21-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a89ca4105f8099de349d139d1090bad387fe2b208b717b288699ca26f179acbe"},
+    {file = "regex-2021.8.21-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d6c2b1d78ceceb6741d703508cd0e9197b34f6bf6864dab30f940f8886e04ade"},
+    {file = "regex-2021.8.21-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a34ba9e39f8269fd66ab4f7a802794ffea6d6ac500568ec05b327a862c21ce23"},
+    {file = "regex-2021.8.21-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ecb6e7c45f9cd199c10ec35262b53b2247fb9a408803ed00ee5bb2b54aa626f5"},
+    {file = "regex-2021.8.21-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:330836ad89ff0be756b58758878409f591d4737b6a8cef26a162e2a4961c3321"},
+    {file = "regex-2021.8.21-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:71a904da8c9c02aee581f4452a5a988c3003207cb8033db426f29e5b2c0b7aea"},
+    {file = "regex-2021.8.21-cp37-cp37m-win32.whl", hash = "sha256:b511c6009d50d5c0dd0bab85ed25bc8ad6b6f5611de3a63a59786207e82824bb"},
+    {file = "regex-2021.8.21-cp37-cp37m-win_amd64.whl", hash = "sha256:93f9f720081d97acee38a411e861d4ce84cbc8ea5319bc1f8e38c972c47af49f"},
+    {file = "regex-2021.8.21-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:3a195e26df1fbb40ebee75865f9b64ba692a5824ecb91c078cc665b01f7a9a36"},
+    {file = "regex-2021.8.21-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:06ba444bbf7ede3890a912bd4904bb65bf0da8f0d8808b90545481362c978642"},
+    {file = "regex-2021.8.21-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8b8d551f1bd60b3e1c59ff55b9e8d74607a5308f66e2916948cafd13480b44a3"},
+    {file = "regex-2021.8.21-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ebbceefbffae118ab954d3cd6bf718f5790db66152f95202ebc231d58ad4e2c2"},
+    {file = "regex-2021.8.21-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ccd721f1d4fc42b541b633d6e339018a08dd0290dc67269df79552843a06ca92"},
+    {file = "regex-2021.8.21-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ae87ab669431f611c56e581679db33b9a467f87d7bf197ac384e71e4956b4456"},
+    {file = "regex-2021.8.21-cp38-cp38-win32.whl", hash = "sha256:38600fd58c2996829480de7d034fb2d3a0307110e44dae80b6b4f9b3d2eea529"},
+    {file = "regex-2021.8.21-cp38-cp38-win_amd64.whl", hash = "sha256:61e734c2bcb3742c3f454dfa930ea60ea08f56fd1a0eb52d8cb189a2f6be9586"},
+    {file = "regex-2021.8.21-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b091dcfee169ad8de21b61eb2c3a75f9f0f859f851f64fdaf9320759a3244239"},
+    {file = "regex-2021.8.21-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:640ccca4d0a6fcc6590f005ecd7b16c3d8f5d52174e4854f96b16f34c39d6cb7"},
+    {file = "regex-2021.8.21-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac95101736239260189f426b1e361dc1b704513963357dc474beb0f39f5b7759"},
+    {file = "regex-2021.8.21-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:b79dc2b2e313565416c1e62807c7c25c67a6ff0a0f8d83a318df464555b65948"},
+    {file = "regex-2021.8.21-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d8b623fc429a38a881ab2d9a56ef30e8ea20c72a891c193f5ebbddc016e083ee"},
+    {file = "regex-2021.8.21-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8021dee64899f993f4b5cca323aae65aabc01a546ed44356a0965e29d7893c94"},
+    {file = "regex-2021.8.21-cp39-cp39-win32.whl", hash = "sha256:d6ec4ae13760ceda023b2e5ef1f9bc0b21e4b0830458db143794a117fdbdc044"},
+    {file = "regex-2021.8.21-cp39-cp39-win_amd64.whl", hash = "sha256:03840a07a402576b8e3a6261f17eb88abd653ad4e18ec46ef10c9a63f8c99ebd"},
+    {file = "regex-2021.8.21.tar.gz", hash = "sha256:faf08b0341828f6a29b8f7dd94d5cf8cc7c39bfc3e67b78514c54b494b66915a"},
 ]
 snowballstemmer = [
     {file = "snowballstemmer-2.1.0-py2.py3-none-any.whl", hash = "sha256:b51b447bea85f9968c13b650126a888aabd4cb4463fca868ec596826325dedc2"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -442,7 +442,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.8,<3.10"
-content-hash = "876117cdaf1d2da92668f026677898ee3e37058136737033be30f9ae7d5496fa"
+content-hash = "e43caf897155292c30d40c9ff8ed4e3e7ef9c659c07cb1e6651aa9f18b4925d5"
 
 [metadata.files]
 appdirs = [

--- a/pre-commit.nix
+++ b/pre-commit.nix
@@ -54,7 +54,6 @@ in
       mypy = {
         enable = true;
         entry = "mypy";
-        excludes = [ "slumba/tests/test_.*\.py" ];
         types_or = [ "python" ];
       };
     };

--- a/pre-commit.nix
+++ b/pre-commit.nix
@@ -54,6 +54,7 @@ in
       mypy = {
         enable = true;
         entry = "mypy";
+        excludes = [ "slumba/tests/test_.*\.py" ];
         types_or = [ "python" ];
       };
     };

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ debugpy = "^1"
 flake8 = "^3"
 importlib-metadata = { version = "^4", python = "<3.8" }
 isort = "^5"
-mypy = "^0.910"
+mypy = "^0.812"
 pydocstyle = "^6"
 pytest = "^6"
 pytest-benchmark = "^3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ mypy = "^0.812"
 pydocstyle = "^6"
 pytest = "^6"
 pytest-benchmark = "^3"
+pytest-randomly = "^3"
 pytest-xdist = "^2"
 
 [tool.pytest.ini_options]

--- a/slumba/__init__.py
+++ b/slumba/__init__.py
@@ -118,8 +118,9 @@ def create_aggregate(
             namebytes,
             num_params,
             flags,
-            # XXX: byref is necessary here because apparently it will not
-            # be garbage collected after the function returns
+            # XXX: byref is necessary here because byref returns a new reference
+            # whereas ctypes.pointer doesn't, and is likely to be destroyed when
+            # this function returns
             byref(c_bool(False)),
             stepfunc(aggregate_class.step.address),
             finalizefunc(aggregate_class.finalize.address),

--- a/slumba/__init__.py
+++ b/slumba/__init__.py
@@ -1,4 +1,5 @@
 import sqlite3
+from ctypes import byref, c_bool
 
 from numba.core.ccallback import CFunc
 from numba.types import ClassType
@@ -117,7 +118,9 @@ def create_aggregate(
             namebytes,
             num_params,
             flags,
-            None,
+            # XXX: byref is necessary here because apparently it will not
+            # be garbage collected after the function returns
+            byref(c_bool(False)),
             stepfunc(aggregate_class.step.address),
             finalizefunc(aggregate_class.finalize.address),
             valuefunc(aggregate_class.value.address),
@@ -130,7 +133,7 @@ def create_aggregate(
             namebytes,
             num_params,
             flags,
-            None,
+            byref(c_bool(False)),
             scalarfunc(0),
             stepfunc(aggregate_class.step.address),
             finalizefunc(aggregate_class.finalize.address),

--- a/slumba/aggregate.py
+++ b/slumba/aggregate.py
@@ -46,8 +46,8 @@ def sqlite_udaf(signature: Signature) -> Callable[[Type], Type]:
 
             if is_not_null_pointer(raw_pointer):
                 agg_ctx = unsafe_cast(raw_pointer, cls)
-                user_data = sqlite3_user_data(ctx)
-                init(agg_ctx, user_data)
+                is_initialized = sqlite3_user_data(ctx)
+                init(agg_ctx, is_initialized)
                 args = make_arg_tuple(step_func, argv)
                 agg_ctx.step(*args)
 
@@ -68,7 +68,8 @@ def sqlite_udaf(signature: Signature) -> Callable[[Type], Type]:
                     result_setter = get_sqlite3_result_function(result)
                     result_setter(ctx, result)
 
-                reset_init(sqlite3_user_data(ctx))
+                is_initialized = sqlite3_user_data(ctx)
+                reset_init(is_initialized)
 
         try:
             value_func = class_type.jit_methods["value"]

--- a/slumba/aggregate.py
+++ b/slumba/aggregate.py
@@ -28,6 +28,10 @@ def sqlite_udaf(signature: Signature) -> Callable[[Type], Type]:
         class_type = cls.class_type
         instance_type = class_type.instance_type
 
+        init_func = class_type.jit_methods["__init__"]
+        init_signature = void(instance_type)
+        init_func.compile(init_signature)
+
         step_func = class_type.jit_methods["step"]
         step_signature = void(instance_type, *signature.args)
         step_func.compile(step_signature)

--- a/slumba/aggregate.py
+++ b/slumba/aggregate.py
@@ -6,12 +6,13 @@ from numba.types import CPointer, intc, voidptr
 
 from .numbaext import (
     get_sqlite3_result_function,
+    init,
     is_not_null_pointer,
     make_arg_tuple,
     sizeof,
     unsafe_cast,
 )
-from .sqlite import sqlite3_aggregate_context, sqlite3_result_null
+from .sqlite import sqlite3_aggregate_context, sqlite3_result_null, sqlite3_user_data
 
 
 def sqlite_udaf(signature: Signature) -> Callable[[Type], Type]:
@@ -43,6 +44,8 @@ def sqlite_udaf(signature: Signature) -> Callable[[Type], Type]:
             raw_pointer = sqlite3_aggregate_context(ctx, sizeof(cls))
             agg_ctx = unsafe_cast(raw_pointer, cls)
             if is_not_null_pointer(agg_ctx):
+                user_data = sqlite3_user_data(ctx)
+                init(agg_ctx, user_data)
                 args = make_arg_tuple(step_func, argv)
                 agg_ctx.step(*args)
 

--- a/slumba/aggregate.py
+++ b/slumba/aggregate.py
@@ -7,7 +7,7 @@ from numba.types import CPointer, intc, voidptr
 from .numbaext import (
     get_sqlite3_result_function,
     init,
-    is_null_pointer,
+    is_not_null_pointer,
     make_arg_tuple,
     reset_init,
     sizeof,
@@ -43,7 +43,8 @@ def sqlite_udaf(signature: Signature) -> Callable[[Type], Type]:
             ctx, argc: int, argv
         ) -> None:  # pragma: no cover
             raw_pointer = sqlite3_aggregate_context(ctx, sizeof(cls))
-            if not is_null_pointer(raw_pointer):
+
+            if is_not_null_pointer(raw_pointer):
                 agg_ctx = unsafe_cast(raw_pointer, cls)
                 user_data = sqlite3_user_data(ctx)
                 init(agg_ctx, user_data)
@@ -57,7 +58,7 @@ def sqlite_udaf(signature: Signature) -> Callable[[Type], Type]:
         @cfunc(void(voidptr))  # type: ignore[misc]
         def finalize(ctx) -> None:  # type: ignore[no-untyped-def]  # pragma: no cover
             raw_pointer = sqlite3_aggregate_context(ctx, sizeof(cls))
-            if not is_null_pointer(raw_pointer):
+            if is_not_null_pointer(raw_pointer):
                 agg_ctx = unsafe_cast(raw_pointer, cls)
                 result = agg_ctx.finalize()
 
@@ -93,7 +94,7 @@ def sqlite_udaf(signature: Signature) -> Callable[[Type], Type]:
             @cfunc(void(voidptr))  # type: ignore[misc]
             def value(ctx) -> None:  # type: ignore[no-untyped-def]  # pragma: no cover
                 raw_pointer = sqlite3_aggregate_context(ctx, sizeof(cls))
-                if not is_null_pointer(raw_pointer):
+                if is_not_null_pointer(raw_pointer):
                     agg_ctx = unsafe_cast(raw_pointer, cls)
                     result = agg_ctx.value()
                     if result is None:
@@ -110,7 +111,7 @@ def sqlite_udaf(signature: Signature) -> Callable[[Type], Type]:
                 ctx, argc: int, argv
             ) -> None:  # pragma: no cover
                 raw_pointer = sqlite3_aggregate_context(ctx, sizeof(cls))
-                if not is_null_pointer(raw_pointer):
+                if is_not_null_pointer(raw_pointer):
                     agg_ctx = unsafe_cast(raw_pointer, cls)
                     agg_ctx.inverse(*make_arg_tuple(inverse_func, argv))
 

--- a/slumba/aggregate.py
+++ b/slumba/aggregate.py
@@ -9,6 +9,7 @@ from .numbaext import (
     init,
     is_null_pointer,
     make_arg_tuple,
+    reset_init,
     sizeof,
     unsafe_cast,
 )
@@ -65,6 +66,8 @@ def sqlite_udaf(signature: Signature) -> Callable[[Type], Type]:
                 else:
                     result_setter = get_sqlite3_result_function(result)
                     result_setter(ctx, result)
+
+                reset_init(sqlite3_user_data(ctx))
 
         try:
             value_func = class_type.jit_methods["value"]

--- a/slumba/aggregate.py
+++ b/slumba/aggregate.py
@@ -114,7 +114,8 @@ def sqlite_udaf(signature: Signature) -> Callable[[Type], Type]:
                 raw_pointer = sqlite3_aggregate_context(ctx, sizeof(cls))
                 if is_not_null_pointer(raw_pointer):
                     agg_ctx = unsafe_cast(raw_pointer, cls)
-                    agg_ctx.inverse(*make_arg_tuple(inverse_func, argv))
+                    args = make_arg_tuple(inverse_func, argv)
+                    agg_ctx.inverse(*args)
 
         cls.step.address = step.address
         cls.finalize.address = finalize.address

--- a/slumba/aggregate.py
+++ b/slumba/aggregate.py
@@ -89,7 +89,7 @@ def sqlite_udaf(signature: Signature) -> Callable[[Type], Type]:
 
         if is_window_function:
             # aggregates can always return a NULL value
-            value_signature = signature.return_type(instance_type)
+            value_signature = finalize_signature
             value_func.compile(value_signature)
 
             @cfunc(void(voidptr))  # type: ignore[misc]
@@ -104,7 +104,7 @@ def sqlite_udaf(signature: Signature) -> Callable[[Type], Type]:
                         result_setter = get_sqlite3_result_function(result)
                         result_setter(ctx, result)
 
-            inverse_signature: Signature = step_signature
+            inverse_signature = step_signature
             inverse_func.compile(inverse_signature)
 
             @cfunc(void(voidptr, intc, CPointer(voidptr)))  # type: ignore[misc,]

--- a/slumba/exceptions.py
+++ b/slumba/exceptions.py
@@ -1,0 +1,15 @@
+from typing import Type, TypeVar
+
+T = TypeVar("T")
+
+
+class MissingAggregateMethod(Exception):
+    def __init__(self, cls: Type[T], method: str) -> None:
+        self.clsname = cls.__name__
+        self.method = method
+        super().__init__(self.clsname, self.method)
+
+    def __str__(self) -> str:
+        return (
+            f"Missing aggregate method `{self.method}` on UDAF class `{self.clsname}`"
+        )

--- a/slumba/exceptions.py
+++ b/slumba/exceptions.py
@@ -13,3 +13,12 @@ class MissingAggregateMethod(Exception):
         return (
             f"Missing aggregate method `{self.method}` on UDAF class `{self.clsname}`"
         )
+
+
+class MissingLibrary(Exception):
+    def __init__(self, library: str) -> None:
+        self.library = library
+        super().__init__(self.library)
+
+    def __str__(self) -> str:
+        return f"Library `{self.library}` not found"

--- a/slumba/numbaext.py
+++ b/slumba/numbaext.py
@@ -499,11 +499,11 @@ def sizeof(
 
 
 @extending.intrinsic  # type: ignore[misc]
-def is_null_pointer(
+def is_not_null_pointer(
     typingctx: Context, raw_pointer_type: types.Integer
 ) -> Tuple[
     Signature,
-    Callable[[BaseContext, Builder, Signature, Tuple[Value, ...]], ICMPInstr],
+    Callable[[BaseContext, Builder, Signature, Tuple[Value]], ICMPInstr],
 ]:
     if isinstance(raw_pointer_type, types.Integer):
         sig = types.boolean(raw_pointer_type)
@@ -512,11 +512,10 @@ def is_null_pointer(
             context: BaseContext,
             builder: Builder,
             signature: Signature,
-            args: Tuple[Value, ...],
+            args: Tuple[Value],
         ) -> ICMPInstr:
-            (instance,) = args
-            return cgutils.is_null(builder, instance)
+            return cgutils.is_not_null(builder, *args)
 
         return sig, codegen
 
-    raise TypeError(f"Cannot check whether a {raw_pointer_type} is a null pointer")
+    raise TypeError(f"Cannot check whether a {raw_pointer_type} is not a null pointer")

--- a/slumba/numbaext.py
+++ b/slumba/numbaext.py
@@ -426,7 +426,9 @@ def map_sqlite_string_to_numba_uni_str(
 
     # SQLite strings are never guaranteed to be anything really, and most
     # certainly not ASCII.
-    uni_str.is_ascii = uni_str.is_ascii.type(0)
+    uni_str.is_ascii = builder.zext(
+        context.get_constant(types.boolean, False), uni_str.is_ascii.type
+    )
 
     # Tell numba to forget about owning the data, because SQLite owns it.
     uni_str.meminfo = cgutils.get_null_value(uni_str.meminfo.type)

--- a/slumba/numbaext.py
+++ b/slumba/numbaext.py
@@ -465,14 +465,14 @@ def get_sqlite3_result_function(
         signature: Signature,
         args: Tuple[Value, ...],
     ) -> CastInstr:
-        # get the appropriate ctypes extraction routine
-        ctypes_function = RESULT_SETTERS[value_type]
+        # get the appropriate setter function
+        result_setter = RESULT_SETTERS[value_type]
 
         # create a numba function type for the converter
-        converter = ctypes_utils.make_function_type(ctypes_function)
+        converter = ctypes_utils.make_function_type(result_setter)
 
         # get the function pointer instruction out
-        return context.get_constant_generic(builder, converter, ctypes_function)
+        return context.get_constant_generic(builder, converter, result_setter)
 
     return sig, codegen
 

--- a/slumba/numbaext.py
+++ b/slumba/numbaext.py
@@ -380,7 +380,7 @@ def make_arg_tuple(
 
         # construct a tuple of arguments (fixed length and known types)
         res = context.make_tuple(builder, tuple_type, converted_args)
-        return imputils.impl_ret_borrowed(context, builder, tuple_type, res)
+        return imputils.impl_ret_new_ref(context, builder, tuple_type, res)
 
     return sig, codegen
 

--- a/slumba/sqlite.py
+++ b/slumba/sqlite.py
@@ -85,6 +85,20 @@ sqlite3_create_function.argtypes = (
     finalizefunc,
 )
 
+sqlite3_create_function_v2 = libsqlite3.sqlite3_create_function_v2
+sqlite3_create_function_v2.restype = c_int
+sqlite3_create_function_v2.argtypes = (
+    c_void_p,
+    c_char_p,
+    c_int,
+    c_int,
+    c_void_p,
+    scalarfunc,
+    stepfunc,
+    finalizefunc,
+    destroyfunc,
+)
+
 try:
     sqlite3_create_window_function = libsqlite3.sqlite3_create_window_function
 except AttributeError:  # pragma: no cover

--- a/slumba/sqlite.py
+++ b/slumba/sqlite.py
@@ -44,6 +44,10 @@ sqlite3_aggregate_context = libsqlite3.sqlite3_aggregate_context
 sqlite3_aggregate_context.argtypes = c_void_p, c_int
 sqlite3_aggregate_context.restype = c_void_p
 
+sqlite3_user_data = libsqlite3.sqlite3_user_data
+sqlite3_user_data.argtypes = (c_void_p,)
+sqlite3_user_data.restype = c_void_p
+
 sqlite3_result_double = libsqlite3.sqlite3_result_double
 sqlite3_result_int64 = libsqlite3.sqlite3_result_int64
 sqlite3_result_int = libsqlite3.sqlite3_result_int

--- a/slumba/sqlite.py
+++ b/slumba/sqlite.py
@@ -1,8 +1,8 @@
 import ctypes
+import ctypes.util
 import sqlite3
 import sys
 from ctypes import (
-    CDLL,
     CFUNCTYPE,
     POINTER,
     c_char_p,
@@ -14,11 +14,12 @@ from ctypes import (
     c_ubyte,
     c_void_p,
 )
-from ctypes.util import find_library
 from typing import Any, Optional
 
 from numba import float64, int32, int64, optional
 from numba.types import string
+
+from .exceptions import MissingLibrary
 
 SQLITE_OK = sqlite3.SQLITE_OK
 SQLITE_VERSION = sqlite3.sqlite_version
@@ -26,17 +27,17 @@ SQLITE_UTF8 = 1
 SQLITE_NULL = 5
 SQLITE_DETERMINISTIC = 0x000000800
 
-sqlite3_path: Optional[str] = find_library("sqlite3")
+sqlite3_path: Optional[str] = ctypes.util.find_library("sqlite3")
 if sqlite3_path is None:  # pragma: no cover
-    raise RuntimeError("Unable to find sqlite3 library")
+    raise MissingLibrary("libsqlite3")
 
-libsqlite3 = CDLL(sqlite3_path)
+libsqlite3 = ctypes.cdll[sqlite3_path]
 
 if sys.platform != "win32":
-    libc_path: Optional[str] = find_library("c")
+    libc_path: Optional[str] = ctypes.util.find_library("c")
     if libc_path is None:  # pragma: no cover
-        raise RuntimeError("Unable to find libc library")
-    libc = CDLL(libc_path)
+        raise MissingLibrary("libc")
+    libc = ctypes.cdll[libc_path]
 else:
     libc = ctypes.cdll.msvcrt
 

--- a/slumba/tests/test_aggregate.py
+++ b/slumba/tests/test_aggregate.py
@@ -148,8 +148,12 @@ def con() -> sqlite3.Connection:
 
 def test_constructor(con: sqlite3.Connection) -> None:
     ((count,),) = con.execute("SELECT count(1) FROM t").fetchall()
-    result = con.execute("SELECT bogus_count() FROM t").fetchall()
-    assert result == [(count + 1,)]
+    ((bogus_count,),) = con.execute("SELECT bogus_count() FROM t").fetchall()
+    assert bogus_count == count + 1
+
+    ((count,),) = con.execute("SELECT count(1) FROM t").fetchall()
+    ((bogus_count,),) = con.execute("SELECT bogus_count() FROM t").fetchall()
+    assert bogus_count == count + 1
 
 
 def test_aggregate(con: sqlite3.Connection) -> None:

--- a/slumba/tests/test_numbaext.py
+++ b/slumba/tests/test_numbaext.py
@@ -1,7 +1,7 @@
 import pytest
 from numba import TypingError, boolean, int64, njit
 
-from slumba.numbaext import is_null_pointer, sizeof, unsafe_cast
+from slumba.numbaext import is_not_null_pointer, sizeof, unsafe_cast
 
 
 def test_sizeof_invalid() -> None:
@@ -20,7 +20,7 @@ def test_is_null_invalid() -> None:
 
         @njit(boolean(int64))  # type: ignore[misc]
         def bad_is_null_pointer(x: int) -> bool:  # pragma: no cover
-            return is_null_pointer(x)
+            return is_not_null_pointer(x)
 
 
 def test_unsafe_case_invalid() -> None:

--- a/slumba/tests/test_numbaext.py
+++ b/slumba/tests/test_numbaext.py
@@ -1,7 +1,7 @@
 import pytest
 from numba import TypingError, boolean, int64, njit
 
-from slumba.numbaext import is_not_null_pointer, sizeof, unsafe_cast
+from slumba.numbaext import is_null_pointer, sizeof, unsafe_cast
 
 
 def test_sizeof_invalid() -> None:
@@ -12,12 +12,15 @@ def test_sizeof_invalid() -> None:
             return sizeof(x)
 
 
-def test_not_null_invalid() -> None:
+@pytest.mark.xfail(  # type: ignore[misc]
+    reason="Numba converts c_void_p from ctypes into an integer"
+)
+def test_is_null_invalid() -> None:
     with pytest.raises(TypingError):
 
         @njit(boolean(int64))  # type: ignore[misc]
-        def bad_not_null(x: int) -> bool:  # pragma: no cover
-            return is_not_null_pointer(x)
+        def bad_is_null_pointer(x: int) -> bool:  # pragma: no cover
+            return is_null_pointer(x)
 
 
 def test_unsafe_case_invalid() -> None:


### PR DESCRIPTION
- chore: clean up shell.nix
- chore(deps): bump nixpkgs
- fix(udaf): compile __init__ functions
- perf: tell mypy to ignore tests because it's way too slow
- fix: actually run constructors
- docs: comment more on how byref works
- refactor: remove unnecessarily complicated null checking functions
- test: add a failing test for aggregate constructors
- docs: add some docs, comments and fix types
- chore: add v2 create function to allow for later destructor usage
- chore: implement reset_init function for resetting the agg context indicator variable
- fix: use reset_init in finalize to indicate that the next step call should reinit
- chore: add safe_decref function
- fix: safely decref the pyobject that we use to store the state of agg initialization
